### PR TITLE
Cypress badge for the README

### DIFF
--- a/.github/workflows/web.e2e.yml
+++ b/.github/workflows/web.e2e.yml
@@ -1,6 +1,9 @@
 name: Scheduled Cypress Tests
 
 on:
+  # This allows you to kick off this workflow manually
+  workflow_dispatch:
+
   schedule:
     # Runs every Monday at 4:00 AM EST
     - cron: '00 9 * * 1'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ## Project: User Registration System
+[![user-registration](https://img.shields.io/endpoint?url=https://cloud.cypress.io/badge/detailed/2xqznk&style=for-the-badge&logo=cypress)](https://cloud.cypress.io/projects/2xqznk/runs)
+
 This project implements a User Registration System, designed to provide a seamless and intuitive interface for users to sign up, log in, and manage their profiles. Built with modern web technologies, this application emphasizes security, user experience, and scalability.
 
 ## Features
@@ -13,6 +15,6 @@ Other Dependencies: Check package.json for a detailed list of libraries and fram
 ## Getting Started
 Clone the Repository: git clone [repository-url]
 Install Dependencies: Run npm install in the project root directory.
-Start the Application: Execute `npm start` to launch the app.
+Start the Application: Execute `npm start` to launch the app and 
 
 `npm run cypress:open` or `npm run cypress:run` from your terminal to manage your Cypress tests


### PR DESCRIPTION
Cypress Badge in README: Added a Cypress badge to the README.md file. This badge displays the current status of our E2E tests, offering a quick and visible way to monitor test outcomes directly from the repository's main page.

Workflow Dispatch for Recorded Runs: Enhanced our GitHub Actions workflow by adding workflow_dispatch trigger capability. This allows us to manually trigger recorded Cypress test runs from the GitHub UI.